### PR TITLE
v. 0.1.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,5 @@
+
+v. 0.0.3
+ * added BaseSourceDocument and BaseSourceDocument classes
+ * minor fixes in other data structures
+ 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+v. 0.1.0
+ * updated for data spec 0.3.0
+ * added iteration with context
+ * renamed SourceDocument to SrcDocument
+ * local load/dump split from SrcDocument, into a LocalSrcDocument class +
+   a module function
+ * added base classes for tabular, tree & sequential docs
+ * chunk payload change to `data` from `text`, to make it more generic
 
 v. 0.0.3
  * added BaseSourceDocument and BaseSourceDocument classes

--- a/README.md
+++ b/README.md
@@ -5,30 +5,20 @@ Personally Identifiable Information (it does *not* contain code for processing
 documents, or extracting PII from documents).
 
 For the full specification embodied by these base data structures, check the
-PIISA Data Specification.
+[PIISA Data Specification].
 
 ## Data structures
 
-Two main data types are defined: PII Source Documents and PII
+Two main data types are defined to hold PII information: PII Entities and PII
 Collections. There is also a Source Document data type.
 
 
 ### PII Source Document
 
 A PII Source Document defines the raw data from which PII is detected. This
-document is modelled as a sequence of chunks, each one having an identifier
-and a raw text content. There could be two variants:
- 
- - a *linear* PII Source Document is just a sequence of chunks
- - in a *hierarchical* PII Source document chunks might contain other chunks,
-   in a nested fashion
-   
-The Python data structure for a chunk is just a Python dictionary; a PII
-Source Document could be a nested dictionary, a list of dictionaries or a
-combination of both.
-
-The official dump representation of a PII Source Document is in the form of a
-YAML file.
+document is modeled as a number of chunks, each one having an identifier and a 
+data contents (a raw text excerpt, or other types of content). This is managed
+in this package by the [SrcDocument] class and subclasses.
 
 
 ### PII Collection
@@ -40,7 +30,7 @@ instance and locate it in the document it belongs to.
 These are the data classes defined:
  * `PiiCollection`: the full collection of PII
  * `PiiEntity`: one PII instance
- * `PiiDetector`: an objecto to describe the module used to generate a given
+ * `PiiDetector`: an object to describe the module used to generate a given
     `PiiEntity` object
 	
 `PiiCollection` objects have a `dump()` method that allows writing them in a
@@ -50,17 +40,13 @@ standard format, with two representations:
    and streaming
 
 
-### Source document
-
-A simple representation of document data as a list of text chunks. It allows
-to define a hierarchy between chunks.
-
-
 ## Online behaviour
 
 There is partial support to use these data classes in an [streaming] fashion,
-proving a way to feed data incrementally.
+providing a way to feed data incrementally.
 
 
 
 [streaming]: doc/stream.md
+[SrcDocument]: doc/srcdocument.md
+[PIISA Data Specification]: https://github.com/piisa/piisa/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ PIISA Data Specification.
 
 ## Data structures
 
-Two main data types are defined: PII Source Documents and PII Collections
+Two main data types are defined: PII Source Documents and PII
+Collections. There is also a Source Document data type.
+
 
 ### PII Source Document
 
@@ -28,6 +30,7 @@ combination of both.
 The official dump representation of a PII Source Document is in the form of a
 YAML file.
 
+
 ### PII Collection
 
 A PII Collection contains a list of detected/extracted PII Entities. Each
@@ -45,3 +48,19 @@ standard format, with two representations:
  * a JSON representation, adequate for storage
  * a NDJSON representation (newline-delimited JSON), intended for processing
    and streaming
+
+
+### Source document
+
+A simple representation of document data as a list of text chunks. It allows
+to define a hierarchy between chunks.
+
+
+## Online behaviour
+
+There is partial support to use these data classes in an [streaming] fashion,
+proving a way to feed data incrementally.
+
+
+
+[streaming]: doc/stream.md

--- a/doc/srcdocument.md
+++ b/doc/srcdocument.md
@@ -1,0 +1,67 @@
+# Source Document
+
+A PII Source Document defines the raw data from which PII is detected. 
+A Source Document, as described in the [data specification], contains two
+elements:
+ * a document header, containing global metadata
+ * a number of *document chunks*, containing the document payload.
+
+The Python data structure for a document chunk is `DocumentChunk`, which
+is just a Python `namedtuple`, with up to three elements:
+ * `id`: chunk identifier
+ * `data`: the chunk contents (a raw text excerpt, or other types of content).
+ * `context`: contextual information associated to the chunk (optional)
+
+
+## Document types
+
+Three document variants are defined:
+ 
+ - a *sequential* PII Source Document is just a sequence of chunks
+ - in a *tree* PII Source Document chunks might contain other chunks,
+   in a nested fashion
+ - a *tabular* PII Source Document has a table structure (rows and columns).
+   
+
+## Base classes
+
+The base Python class to manage a source document is the `SrcDocument` class.
+This is an abstract class; to be usable a child class needs to implement the 
+`get_chunks()` method, which yields an iterator over the document chunks
+(producing chunk payloads).
+
+There are three subclasses of `SrcDocument`, for each of the three types of
+documents:
+ * `SequentialSrcDocument`
+ * `TreeSrcDocument`
+ * `TabularSrcDocument`
+
+These are still abstract classes, so they still need a subclass implementing
+the `get_chunks()` method (or, in the case of the `TreeSrcDocument`, a
+`top_chunks()` method).
+
+
+## Local document classes
+
+One full instance of a `SrcDocument` is the `LocalSrcDocument` class, which
+can hold all document chunks in memory, and can load/dump to a file. 
+
+Subclasses of `LocalSrcDocument` are also defined for each of the three
+document types:
+ * `SequentialLocalSrcDocument`
+ * `TreeLocalSrcDocument`
+ * `TabularLocalSrcDocument`
+
+
+## File format
+
+The official dump representation of a PII Source Document is in the form of a
+YAML file, typically using the [block literal style], to ease human reading.
+
+However a JSON representation would also be processed by the package (since
+JSON is a subset of YAML anyway).
+
+
+
+[data specification]: https://github.com/piisa/piisa/
+[block literal style]: https://yaml.org/spec/1.2.2/#812-literal-style

--- a/doc/stream.md
+++ b/doc/stream.md
@@ -1,0 +1,33 @@
+# Stream processing
+
+In order to be able to process potentially huge documents, the data structures
+should allow stream processing. Currently this is the status:
+
+## Source documents
+
+The standard `SourceDocument` class can only process full local documents,
+since it either loads them from file, or accepts the full set of document
+chunks in the constructor or the `set_chunks()` method.
+
+In order to provide stream processing capabilities:
+ * subclass the `BaseSourceDocument` into an e.g. `StraeamSourceDocument`
+ * implement a `get_chunks()` method in the subclass, which must return
+   an iterator producing `DocumentChunk` objects
+   
+This should be enough to let the tools process the document in a streaming
+fashion.
+
+
+## PiiCollections
+
+Currently the PiiCollection format does not allow a fully streamable operation;
+the PII instances need to be fully computed before the data can be dumped. This
+is mostly because there is a data header that contains the list of PII
+Detectors, and it gets built as new PII instances are added.
+
+Nevertheless the data _can_ be dumped incrementally into an output file-like
+object, if the NDJSON format is chosen.
+
+_A future version will be made fully streamable by **preloading** all
+detectors that might get used, so that the header can be dumped immediately_
+

--- a/doc/stream.md
+++ b/doc/stream.md
@@ -5,17 +5,22 @@ should allow stream processing. Currently this is the status:
 
 ## Source documents
 
-The standard `SourceDocument` class can only process full local documents,
-since it either loads them from file, or accepts the full set of document
-chunks in the constructor or the `set_chunks()` method.
+The standard `SrcDocument` abstract base class will happily iterate in a
+streaming fashion if the child class provides a `get_chunks()` method that
+yields chunks in iteration.
 
-In order to provide stream processing capabilities:
- * subclass the `BaseSourceDocument` into an e.g. `StraeamSourceDocument`
+So in order to provide stream processing capabilities:
+ * subclass the `SrcDocument` into an e.g. `StreamingSrcDocument`
  * implement a `get_chunks()` method in the subclass, which must return
-   an iterator producing `DocumentChunk` objects
+   an iterator producing chunks (a chunk must be either a dict containing a
+   `data` member, or just the chunk payload)
    
-This should be enough to let the tools process the document in a streaming
-fashion.
+This should be enough to let the tools process the document incrementally.
+
+The `LocalSrcDocument` subclass and variants can only process full local
+documents, since it either loads them from file, or accepts the full set of
+document chunks in the constructor or the `set_chunks()` method.
+
 
 
 ## PiiCollections

--- a/src/pii_data/__init__.py
+++ b/src/pii_data/__init__.py
@@ -1,5 +1,5 @@
 # Package version
-VERSION = "0.0.2"
+VERSION = "0.0.3"
 
 # Data format version
 FORMAT_VERSION = "0.2.1"

--- a/src/pii_data/__init__.py
+++ b/src/pii_data/__init__.py
@@ -1,5 +1,5 @@
 # Package version
-VERSION = "0.0.3"
+VERSION = "0.1.0"
 
 # Data format version
-FORMAT_VERSION = "0.2.1"
+FORMAT_VERSION = "0.3.0"

--- a/src/pii_data/doc/__init__.py
+++ b/src/pii_data/doc/__init__.py
@@ -1,2 +1,2 @@
-from .load import RawReader, load_raw
+from .rawtext import RawReader, load_raw
 from .dump import dump_raw, dump_yaml

--- a/src/pii_data/doc/dump.py
+++ b/src/pii_data/doc/dump.py
@@ -4,6 +4,7 @@ Dump raw documents
 
 from yaml import dump
 from yaml import SafeDumper as Dumper
+from collections import defaultdict
 
 from typing import Dict, TextIO
 
@@ -17,17 +18,24 @@ def text_representer(dumper, data):
     """
     A YAML representer to ensure text nodes are dumped in block literal style
     """
-    return dumper.represent_scalar('tag:yaml.org,2002:str', str(data),
-                                   style='|')
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(data),
+                                   style="|")
+
+def defaultdict_representer(dumper, data):
+    """
+    A YAML representer to ensure text nodes are dumped in block literal style
+    """
+    return dumper.represent_dict(data)
 
 
 def dump_yaml(doc: Dict, outputfile: str, indent: int):
     """
-    Dump a PII Source Document to YAML format.
+    Dump the data for a  PII Source Document into a YAML file.
     """
     mydumper = Dumper
     mydumper.add_representer(TextNode, text_representer)
-    with open(outputfile, 'w', encoding='utf-8') as f:
+    mydumper.add_representer(defaultdict, defaultdict_representer)
+    with open(outputfile, "w", encoding="utf-8") as f:
         yaml = dump(doc, Dumper=mydumper, sort_keys=False, allow_unicode=True,
                     default_flow_style=False)
         f.write(yaml)
@@ -40,16 +48,17 @@ def _dump_chunk(chunk: Dict, out: TextIO, level: int, indent: int):
     """
     Dump a document chunk as raw text lines, possibly with leading indent
     """
-    for line in chunk['text'].split('\n'):
-        print(' ' * (level-1)*indent, line, sep='', file=out)
-    for subchunk in chunk.get('chunks', []):
+    for line in chunk["data"].split("\n"):
+        print(" " * (level-1)*indent, line, sep="", file=out)
+    for subchunk in chunk.get("chunks", []):
         _dump_chunk(subchunk, out, level+1, indent)
 
 
 def dump_raw(doc: Dict, outputfile: str, indent: int):
     """
-    Convert a YAML PII Source Document to plain text
+    Dump the data for a  PII Source Document into a plain text file, possibly
+    with indentation to preserve the tree structure.
     """
-    with open(outputfile, 'w', encoding='utf-8') as f:
-        for chunk in doc.get('chunks', []):
+    with open(outputfile, "w", encoding="utf-8") as f:
+        for chunk in doc.get("chunks", []):
             _dump_chunk(chunk, f, 1, indent)

--- a/src/pii_data/doc/load.py
+++ b/src/pii_data/doc/load.py
@@ -5,7 +5,7 @@ Read raw documents
 from typing import Dict, TextIO
 
 from .utils import TextNode
-
+from ..helper.io import openfile
 
 
 class RawReader:
@@ -55,7 +55,7 @@ class RawReader:
         '''
         Open a raw text file and read it as a PII Source Document
         '''
-        with open(inputfile, encoding='utf-8') as f:
+        with openfile(inputfile) as f:
             return self.read_file(f)
 
 

--- a/src/pii_data/helper/exception.py
+++ b/src/pii_data/helper/exception.py
@@ -27,7 +27,14 @@ class ProcException(PiiDataException):
     pass
 
 
-class PiiUnimplemented(PiiDataException):
+class FileException(ProcException):
+    """
+    An problem with a file
+    """
+    pass
+
+
+class UnimplementedException(PiiDataException):
     """
     Unimplemented methods/functions
     """

--- a/src/pii_data/helper/io.py
+++ b/src/pii_data/helper/io.py
@@ -1,10 +1,58 @@
+"""
+Code to open & read local files
+"""
+
+
+import sys
+from pathlib import Path
+import gzip
+import bz2
+import lzma
+import json
 from yaml import load as yaml_load, SafeLoader as YamlLoader
 
-from typing import Dict
+from typing import Dict, TextIO
+
+from .exception import InvArgException
+
+
+CHARSET_ENCODING = "utf-8"
+
+
+def openfile(name: str, mode: str = 'r') -> TextIO:
+    """
+    Open files, raw text or compressed (gzip, bzip2 or xz)
+    """
+    name = str(name)
+    if name == "-":
+        return sys.stdout if mode.startswith("w") else sys.stdin
+    elif name.endswith(".gz"):
+        return gzip.open(name, mode, encoding=CHARSET_ENCODING)
+    elif name.endswith(".bz2"):
+        return bz2.open(name, mode, encoding=CHARSET_ENCODING)
+    elif name.endswith(".xz"):
+        return lzma.open(name, mode, encoding=CHARSET_ENCODING)
+    else:
+        return open(name, mode, encoding=CHARSET_ENCODING)
+
 
 def load_yaml(filename: str) -> Dict:
     """
     Load a YAML file
     """
-    with open(filename, encoding='utf-8') as f:
+    with openfile(filename) as f:
         return yaml_load(f, Loader=YamlLoader)
+
+
+def load_datafile(filename: str) -> Dict:
+    """
+    Load a YAML or JSON file
+    """
+    filepath = Path(filename)
+    if '.json' in filepath.suffixes:
+        with openfile(filename) as f:
+            return json.load(f)
+    elif '.yml' in filepath.suffixes or '.yaml' in filepath.suffixes:
+        return load_yaml(filename)
+    else:
+        raise InvArgException('cannot load "{}": unsupported format')

--- a/src/pii_data/types/__init__.py
+++ b/src/pii_data/types/__init__.py
@@ -1,4 +1,4 @@
-from .document import SourceDocument
+from .document import SrcDocument
 from .piienum import PiiEnum
 from .piientity import PiiEntity
 from .piicollection import PiiDetector, PiiCollection

--- a/src/pii_data/types/__init__.py
+++ b/src/pii_data/types/__init__.py
@@ -1,2 +1,4 @@
+from .document import SourceDocument
 from .piienum import PiiEnum
 from .piientity import PiiEntity
+from .piicollection import PiiDetector, PiiCollection

--- a/src/pii_data/types/document.py
+++ b/src/pii_data/types/document.py
@@ -1,119 +1,194 @@
 """
-The object holding document data.
-A base object is provided, and them a subclass to hold data for a local
-document.
-Streaming document subclasses would need to implement at least the get_chunks()
-method, producing an iterable of chunks.
+The SrcDocument object holding document data.
+
+A base abstract class is provided, subclasses need to implement at least the
+get_chunks() method, producing an iterable of chunks.
 """
 
 
-from collections import namedtuple
+from collections import namedtuple, defaultdict
+from types import MappingProxyType
 import uuid
 
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Tuple
 
-from ..doc import dump_raw, dump_yaml
-from ..helper.exception import InvArgException, FileException, UnimplementedException
-from ..helper.io import load_datafile
+from ..helper.exception import UnimplementedException
 
 
 # The contents of a document chunk:
 #  - a chunk id
 #  - the text content
-#  - a context for the chunk (TBD)
-DocumentChunk = namedtuple('DocumentChunk', 'id text context', defaults=[None])
+#  - a context for the chunk (optional)
+DocumentChunk = namedtuple("DocumentChunk", "id data context", defaults=[None])
 
 
 
-class BaseSourceDocument:
+class SrcDocument:
     """
     An abstract base object to hold the data for a document to be processed.
     Child classes need to provide at least a get_chunks method
     """
 
-    def __init__(self, id: str = None):
-        self.id = id if id is not None else str(uuid.uuid4())
+    def __init__(self, document_info: Dict = None,
+                 add_chunk_context: bool = False):
+        """
+          :param document_info: document general information
+          :param add_chunk_context: add context information when iterating over
+           chunks
+        """
+        self._do_ctx = add_chunk_context
+        self._chunk_id = 0
+        self._meta = defaultdict(dict)
+        self.set_header_document(document_info)
 
 
     def __repr__(self) -> str:
-        return f'<SourceDocument {self.id}>'
+        return f"<SrcDocument {self._meta['document']['id']}>"
+
+
+    @property
+    def header(self):
+        """
+        Return a read-only representation of the full header
+        """
+        return MappingProxyType(self._meta)
 
 
     def set_id(self, id: str):
-        self.id = id
+        """
+        Set the document identifier inside the document metadata
+        """
+        self._meta["document"]["id"] = id
 
 
-    def __iter__(self):
-        return self.get_chunks()
+    def set_header_document(self, document_info: Dict = None):
+        """
+        Set the data for the document-level info (part of the document
+        metadata)
+        If not present, a document id is automatically added as a random UUID
+        """
+        glb = document_info or {}
+        if "id" not in glb:
+            glb["id"] = str(uuid.uuid4())
+        self._meta["document"] = glb
+
+
+    def add_metadata(self, **kwargs):
+        """
+        Update the document metadata elements, adding all passed arguments
+        (which should be dictionaries)
+        """
+        for k, v in kwargs.items():
+            self._meta[k].update(v)
+
+
+    def _chunk(self, before: Tuple, current: Tuple, after: Tuple) -> Dict:
+        """
+        Create a chunk object, with context
+        """
+        ctx = self._ctx.copy()
+        if before:
+            ctx["before"] = before[1]
+        if after:
+            ctx["after"] = after[1]
+        data = *current, ctx
+        return DocumentChunk(*data)
+
+
+    def iter_chunks(self, add_context: bool = None) -> Iterable[Dict]:
+        """
+        Iterator method, with additional options
+        Produce an iterable over document chunks, with or without context
+        (depending on the object config, or on the passed extra argument).
+
+        Calls the get_chunks() method, to be implemented by subclasses.
+        """
+        before = current = None
+        if add_context is None:
+            add_context = self._do_ctx
+        if add_context:
+            self._ctx = {k: MappingProxyType(v) for k, v in self._meta.items()}
+
+        for data in self.get_chunks():
+
+            # Get chunk_id and payload
+            chunk_id = None
+            if isinstance(data, dict) and "data" in data:
+                chunk_id = data.get("id")
+                data = data["data"]
+            if chunk_id is None:
+                self._chunk_id += 1
+                chunk_id = self._chunk_id
+            data = (str(chunk_id), data)
+
+            # Render without context
+            if not add_context:
+                yield DocumentChunk(*data)
+                continue
+
+            # Render with context: track the chunks before & after
+            if before is None:
+                before = data
+            elif current is None:
+                yield self._chunk(None, before, data)
+                current = data
+            else:
+                yield self._chunk(before, current, data)
+                before = current
+                current = data
+
+        # Last chunk?
+        if add_context:
+            if current:
+                yield self._chunk(before, current, None)
+            elif before:
+                yield self._chunk(None, before, None)
+
+
+    def __iter__(self) -> Iterable[Dict]:
+        return self.iter_chunks()
 
 
     def get_chunks(self) -> Iterable[DocumentChunk]:
-        raise UnimplementedException('abstract class')
+        raise UnimplementedException("abstract class")
 
 
 # --------------------------------------------------------------------------
 
 
-class SourceDocument(BaseSourceDocument):
+class TreeSrcDocument(SrcDocument):
     """
-    A document fully loaded in memory
+    A tree document, as an abstract class.
+    Subclasses need to implement the top_chunks() method, which gives an
+    iterable over just the document top-level chunks
     """
 
-    def __init__(self, id: str = None, chunks: Iterable[Dict] = None):
-        super().__init__(id)
-        self.set_chunks(chunks)
-
-
-    def set_chunks(self, chunks: Iterable[Dict]):
-        self.chunks = list(chunks) if chunks else None
-
-
-    def _data_iter(self, elem: Dict) -> Iterable[DocumentChunk]:
-        text = elem.get('text')
+    def _yield_chunks(self, chunk: Dict) -> Iterable[DocumentChunk]:
+        """
+        Return a sequence of chunks from an element in the document tree
+        """
+        # This chunk
+        text = chunk.get("data")
         if text:
-            yield DocumentChunk(elem['id'], text)
-        for chunk in elem.get('chunks', []):
-            yield from self._data_iter(chunk)
+            yield text
+        # Child chunks
+        for subchunk in chunk.get("chunks", []):
+            yield from self._yield_chunks(subchunk)
 
 
-    def get_chunks(self) -> Iterable[DocumentChunk]:
+    def get_chunks(self) -> Iterable[str]:
         """
-        Get an iterable over document chunks
+        Return all chunks from the document tree, traversing it deep-first
+        Requires a top_chunks() method
         """
-        for chunk in self.chunks:
-            yield from self._data_iter(chunk)
+        for chunk in self.top_chunks():
+            yield from self._yield_chunks(chunk)
 
 
-    def load(self, filename: str):
-        """
-        Load a document from a file, in yaml format
-        """
-        data = load_datafile(filename)
-        try:
-            self.chunks = data['chunks']
-        except KeyError:
-            raise FileException('no chunks found in: "{}"', filename)
-        if 'id' in data:
-            self.id = data['id']
+    def top_chunks(self) -> Iterable[Dict]:
+        raise UnimplementedException("abstract class")
 
 
-    def dump(self, outname: str, format: str = None, indent: int = 0):
-        """
-        Dump the document to an output file
-        """
-        if format is not None:
-            format = str(format).lower()
-        elif outname.endswith(('.yml', '.yaml')):
-            format = 'yml'
-        elif outname.endswith('.txt'):
-            format = 'txt'
-        else:
-            raise InvArgException('unspecified format for: {}', outname)
 
-        data = {'docid': self.id,
-                'chunks': self.chunks}
-
-        if format in ('yaml', 'yml'):
-            dump_yaml(data, outname, indent)
-        else:
-            dump_raw(data, outname, indent)
+class TabularSrcDocument(SrcDocument):
+    pass

--- a/src/pii_data/types/document.py
+++ b/src/pii_data/types/document.py
@@ -1,0 +1,119 @@
+"""
+The object holding document data.
+A base object is provided, and them a subclass to hold data for a local
+document.
+Streaming document subclasses would need to implement at least the get_chunks()
+method, producing an iterable of chunks.
+"""
+
+
+from collections import namedtuple
+import uuid
+
+from typing import Dict, Iterable
+
+from ..doc import dump_raw, dump_yaml
+from ..helper.exception import InvArgException, FileException, UnimplementedException
+from ..helper.io import load_datafile
+
+
+# The contents of a document chunk:
+#  - a chunk id
+#  - the text content
+#  - a context for the chunk (TBD)
+DocumentChunk = namedtuple('DocumentChunk', 'id text context', defaults=[None])
+
+
+
+class BaseSourceDocument:
+    """
+    An abstract base object to hold the data for a document to be processed.
+    Child classes need to provide at least a get_chunks method
+    """
+
+    def __init__(self, id: str = None):
+        self.id = id if id is not None else str(uuid.uuid4())
+
+
+    def __repr__(self) -> str:
+        return f'<SourceDocument {self.id}>'
+
+
+    def set_id(self, id: str):
+        self.id = id
+
+
+    def __iter__(self):
+        return self.get_chunks()
+
+
+    def get_chunks(self) -> Iterable[DocumentChunk]:
+        raise UnimplementedException('abstract class')
+
+
+# --------------------------------------------------------------------------
+
+
+class SourceDocument(BaseSourceDocument):
+    """
+    A document fully loaded in memory
+    """
+
+    def __init__(self, id: str = None, chunks: Iterable[Dict] = None):
+        super().__init__(id)
+        self.set_chunks(chunks)
+
+
+    def set_chunks(self, chunks: Iterable[Dict]):
+        self.chunks = list(chunks) if chunks else None
+
+
+    def _data_iter(self, elem: Dict) -> Iterable[DocumentChunk]:
+        text = elem.get('text')
+        if text:
+            yield DocumentChunk(elem['id'], text)
+        for chunk in elem.get('chunks', []):
+            yield from self._data_iter(chunk)
+
+
+    def get_chunks(self) -> Iterable[DocumentChunk]:
+        """
+        Get an iterable over document chunks
+        """
+        for chunk in self.chunks:
+            yield from self._data_iter(chunk)
+
+
+    def load(self, filename: str):
+        """
+        Load a document from a file, in yaml format
+        """
+        data = load_datafile(filename)
+        try:
+            self.chunks = data['chunks']
+        except KeyError:
+            raise FileException('no chunks found in: "{}"', filename)
+        if 'id' in data:
+            self.id = data['id']
+
+
+    def dump(self, outname: str, format: str = None, indent: int = 0):
+        """
+        Dump the document to an output file
+        """
+        if format is not None:
+            format = str(format).lower()
+        elif outname.endswith(('.yml', '.yaml')):
+            format = 'yml'
+        elif outname.endswith('.txt'):
+            format = 'txt'
+        else:
+            raise InvArgException('unspecified format for: {}', outname)
+
+        data = {'docid': self.id,
+                'chunks': self.chunks}
+
+        if format in ('yaml', 'yml'):
+            dump_yaml(data, outname, indent)
+        else:
+            dump_raw(data, outname, indent)

--- a/src/pii_data/types/localdoc.py
+++ b/src/pii_data/types/localdoc.py
@@ -1,0 +1,117 @@
+"""
+Some subclasses of SrcDocument that can read/write data from/to a local file.
+"""
+
+
+from typing import Dict, Iterable, Union
+
+from ..doc import dump_raw, dump_yaml
+from ..helper.exception import InvArgException, FileException, UnimplementedException
+from ..helper.io import load_datafile
+
+from .document import SrcDocument, DocumentChunk, TreeSrcDocument
+
+CHUNK_TYPE = Union[Dict, str]
+
+
+TYPES = {'SequentialLocalSrcDocument': 'sequential',
+         'TreeLocalSrcDocument': 'tree',
+         'TabularLocalSrcDocument': 'tabular'}
+
+# --------------------------------------------------------------------------
+
+
+class LocalSrcDocument(SrcDocument):
+    """
+    A document that can be loaded/saved to a local file
+    """
+
+    def __init__(self, document_header: Dict = None,
+                 add_chunk_context: bool = False,
+                 chunks: Iterable[CHUNK_TYPE] = None):
+        """
+          :param document_header: document general information
+          :param add_chunk_context: add context information when iterating over
+            chunks
+          :param chunks: document chunks
+        """
+        super().__init__(document_header, add_chunk_context)
+        self.set_chunks(chunks)
+        dtype = TYPES.get(self.__class__.__name__)
+        if dtype:
+            self.add_metadata(document={'type': dtype})
+
+
+    def dump(self, outname: str, format: str = None, indent: int = 0):
+        """
+        Dump the document to an output file
+        """
+        if format is not None:
+            format = str(format).lower()
+        elif outname.endswith(('.yml', '.yaml')):
+            format = 'yml'
+        elif outname.endswith('.txt'):
+            format = 'txt'
+        else:
+            raise InvArgException('unspecified format for: {}', outname)
+
+        data = {'header': self._meta, 'chunks': list(self.get_chunks())}
+        if format in ('yaml', 'yml'):
+            dump_yaml(data, outname, indent)
+        else:
+            dump_raw(data, outname, indent)
+
+
+    def set_chunks(self, chunks: Iterable[Dict]):
+        self._chk = chunks if chunks else None
+
+
+    def get_chunks(self) -> Iterable[DocumentChunk]:
+        """
+        Get an iterable over document chunks
+        """
+        return iter(self._chk)
+
+
+# --------------------------------------------------------------------------
+
+
+class TreeLocalSrcDocument(LocalSrcDocument, TreeSrcDocument):
+
+    def get_chunks_tree(self) -> Iterable[DocumentChunk]:
+        """
+        Get an iterable over document chunks
+        """
+        for chunk in self._chk:
+            yield from self._yield_chunk(chunk)
+
+
+class TabularLocalSrcDocument(LocalSrcDocument):
+    pass
+
+
+class SequentialLocalSrcDocument(LocalSrcDocument):
+    pass
+
+
+# --------------------------------------------------------------------------
+
+
+def load_file(filename: str,
+              add_chunk_context: bool = False) -> LocalSrcDocument:
+    """
+    Load a document stored in a YAML file
+    """
+    data = load_datafile(filename)
+    hdr = data.get('header', {})
+    mtype = hdr.get('type')
+    if mtype == 'tree':
+        Obj = TreeLocalSrcDocument
+    elif mtype == 'tabular':
+        Obj = TabularLocalSrcDocument
+    else:
+        Obj = SequentialLocalSrcDocument
+
+    doc = Obj(add_chunk_context=add_chunk_context, chunks=data.get('chunks'))
+    doc.add_metadata(**hdr)
+    return doc

--- a/test/data/doc-example-id.yaml
+++ b/test/data/doc-example-id.yaml
@@ -1,0 +1,64 @@
+docid: "00000-11111"
+chunks:
+- id: 1
+  text: |-
+    PII management specification
+  chunks:
+  - id: 2
+    text: |-
+      Some rough initial ideas
+- id: 3
+  text: |-
+    Overall architecture
+  chunks:
+  - id: 4
+    text: |-
+      The general structure of a framework dealing with PII management could be visualized as the following diagram:
+  - id: 5
+    text: |-
+      There are up to four processing blocks for such a framework:
+  - id: 6
+    text: |-
+      1. Preprocessing: block whose mission is to read a document in an arbitrary format (a Word Document, a Web page, a PDF file, etc) and produce a normalized version, retaining only a simplified version of the high-level structure and all the text data.
+  - id: 7
+    text: |-
+      2. Detection: block in charge of processing input data (usually in text format) and performing detection of candidates to be assigned as PII data. This block uses as input:
+    chunks:
+    - id: 8
+      text: |-
+        ◦ source document. we will consider a normalized data format that conveys the raw text contents, together with some structural information (which can provide useful hints to the PII Detection modules about the relations between text chunks)
+    - id: 9
+      text: |-
+        ◦ configuration information: specification of contextual elements affecting detection (e.g. text language, applicable countries, etc)
+    - id: 10
+      text: |-
+        ◦ component information: the set of available PII Detectors that can be used (assuming we take a modular approach, there might be a database of “pluggable modules” we can use for PII detection). Each Detector will define the type and parameters of PII that can detect.
+  - id: 11
+    text: |-
+      3. Decision: block that takes a number of PII candidates, as produced by the Detection block, and consolidates that information, producing as final result the set of PII elements in the text that need to be addressed. In the process it might combine PII candidates, choose among overlapping PII candidates, reject others, etc. This block uses as input:
+    chunks:
+    - id: 12
+      text: |-
+        ◦ Candidate list: A list of detected PII candidates
+    - id: 13
+      text: |-
+        ◦ Configuration information, as provided by the Decision block (language, countries, etc)
+    - id: 14
+      text: |-
+        ◦ An optional purpose/application scenario, to guide the decisions
+    - id: 15
+      text: |-
+        ◦ Context information, as defined in its own configuration. This might include: requirements on PII specificity, sensitivity and scarcity, applicable regulations, etc
+  - id: 16
+    text: |-
+      4. Transformation. This is the block that takes the decided PII entities, and acts upon them, depending on the intended purpose.
+  - id: 17
+    text: |-
+      There can be different Transformation blocks, all of them sharing the same interface but providing different outcomes. Some examples are:
+    chunks:
+    - id: 18
+      text: |-
+        • Anonymization: modify the text to eliminate decided PII entities. Depending on options they can be replaced by placeholders, dummy values, generated fake PII data, etc
+    - id: 19
+      text: |-
+        • Analytics:  provide the capability to extract and visualize aggregated statistics on decided PII and their associated parameters

--- a/test/data/doc-example-tree-id.yaml
+++ b/test/data/doc-example-tree-id.yaml
@@ -1,63 +1,67 @@
+header:
+  document:
+    id: "00000-11111"
+    type: tree
 chunks:
 - id: 1
-  text: |-
+  data: |-
     PII management specification
   chunks:
   - id: 2
-    text: |-
+    data: |-
       Some rough initial ideas
 - id: 3
-  text: |-
+  data: |-
     Overall architecture
   chunks:
   - id: 4
-    text: |-
+    data: |-
       The general structure of a framework dealing with PII management could be visualized as the following diagram:
   - id: 5
-    text: |-
+    data: |-
       There are up to four processing blocks for such a framework:
   - id: 6
-    text: |-
+    data: |-
       1. Preprocessing: block whose mission is to read a document in an arbitrary format (a Word Document, a Web page, a PDF file, etc) and produce a normalized version, retaining only a simplified version of the high-level structure and all the text data.
   - id: 7
-    text: |-
+    data: |-
       2. Detection: block in charge of processing input data (usually in text format) and performing detection of candidates to be assigned as PII data. This block uses as input:
     chunks:
     - id: 8
-      text: |-
+      data: |-
         ◦ source document. we will consider a normalized data format that conveys the raw text contents, together with some structural information (which can provide useful hints to the PII Detection modules about the relations between text chunks)
     - id: 9
-      text: |-
+      data: |-
         ◦ configuration information: specification of contextual elements affecting detection (e.g. text language, applicable countries, etc)
     - id: 10
-      text: |-
+      data: |-
         ◦ component information: the set of available PII Detectors that can be used (assuming we take a modular approach, there might be a database of “pluggable modules” we can use for PII detection). Each Detector will define the type and parameters of PII that can detect.
   - id: 11
-    text: |-
+    data: |-
       3. Decision: block that takes a number of PII candidates, as produced by the Detection block, and consolidates that information, producing as final result the set of PII elements in the text that need to be addressed. In the process it might combine PII candidates, choose among overlapping PII candidates, reject others, etc. This block uses as input:
     chunks:
     - id: 12
-      text: |-
+      data: |-
         ◦ Candidate list: A list of detected PII candidates
     - id: 13
-      text: |-
+      data: |-
         ◦ Configuration information, as provided by the Decision block (language, countries, etc)
     - id: 14
-      text: |-
+      data: |-
         ◦ An optional purpose/application scenario, to guide the decisions
     - id: 15
-      text: |-
+      data: |-
         ◦ Context information, as defined in its own configuration. This might include: requirements on PII specificity, sensitivity and scarcity, applicable regulations, etc
   - id: 16
-    text: |-
+    data: |-
       4. Transformation. This is the block that takes the decided PII entities, and acts upon them, depending on the intended purpose.
   - id: 17
-    text: |-
+    data: |-
       There can be different Transformation blocks, all of them sharing the same interface but providing different outcomes. Some examples are:
     chunks:
     - id: 18
-      text: |-
+      data: |-
         • Anonymization: modify the text to eliminate decided PII entities. Depending on options they can be replaced by placeholders, dummy values, generated fake PII data, etc
     - id: 19
-      text: |-
+      data: |-
         • Analytics:  provide the capability to extract and visualize aggregated statistics on decided PII and their associated parameters

--- a/test/data/doc-example-tree.yaml
+++ b/test/data/doc-example-tree.yaml
@@ -1,64 +1,66 @@
-docid: "00000-11111"
+header:
+  document:
+    type: tree
 chunks:
 - id: 1
-  text: |-
+  data: |-
     PII management specification
   chunks:
   - id: 2
-    text: |-
+    data: |-
       Some rough initial ideas
 - id: 3
-  text: |-
+  data: |-
     Overall architecture
   chunks:
   - id: 4
-    text: |-
+    data: |-
       The general structure of a framework dealing with PII management could be visualized as the following diagram:
   - id: 5
-    text: |-
+    data: |-
       There are up to four processing blocks for such a framework:
   - id: 6
-    text: |-
+    data: |-
       1. Preprocessing: block whose mission is to read a document in an arbitrary format (a Word Document, a Web page, a PDF file, etc) and produce a normalized version, retaining only a simplified version of the high-level structure and all the text data.
   - id: 7
-    text: |-
+    data: |-
       2. Detection: block in charge of processing input data (usually in text format) and performing detection of candidates to be assigned as PII data. This block uses as input:
     chunks:
     - id: 8
-      text: |-
+      data: |-
         ◦ source document. we will consider a normalized data format that conveys the raw text contents, together with some structural information (which can provide useful hints to the PII Detection modules about the relations between text chunks)
     - id: 9
-      text: |-
+      data: |-
         ◦ configuration information: specification of contextual elements affecting detection (e.g. text language, applicable countries, etc)
     - id: 10
-      text: |-
+      data: |-
         ◦ component information: the set of available PII Detectors that can be used (assuming we take a modular approach, there might be a database of “pluggable modules” we can use for PII detection). Each Detector will define the type and parameters of PII that can detect.
   - id: 11
-    text: |-
+    data: |-
       3. Decision: block that takes a number of PII candidates, as produced by the Detection block, and consolidates that information, producing as final result the set of PII elements in the text that need to be addressed. In the process it might combine PII candidates, choose among overlapping PII candidates, reject others, etc. This block uses as input:
     chunks:
     - id: 12
-      text: |-
+      data: |-
         ◦ Candidate list: A list of detected PII candidates
     - id: 13
-      text: |-
+      data: |-
         ◦ Configuration information, as provided by the Decision block (language, countries, etc)
     - id: 14
-      text: |-
+      data: |-
         ◦ An optional purpose/application scenario, to guide the decisions
     - id: 15
-      text: |-
+      data: |-
         ◦ Context information, as defined in its own configuration. This might include: requirements on PII specificity, sensitivity and scarcity, applicable regulations, etc
   - id: 16
-    text: |-
+    data: |-
       4. Transformation. This is the block that takes the decided PII entities, and acts upon them, depending on the intended purpose.
   - id: 17
-    text: |-
+    data: |-
       There can be different Transformation blocks, all of them sharing the same interface but providing different outcomes. Some examples are:
     chunks:
     - id: 18
-      text: |-
+      data: |-
         • Anonymization: modify the text to eliminate decided PII entities. Depending on options they can be replaced by placeholders, dummy values, generated fake PII data, etc
     - id: 19
-      text: |-
+      data: |-
         • Analytics:  provide the capability to extract and visualize aggregated statistics on decided PII and their associated parameters

--- a/test/data/minidoc-example.yaml
+++ b/test/data/minidoc-example.yaml
@@ -1,0 +1,11 @@
+chunks:
+- id: 1
+  text: |-
+    PII management specification
+- id: 2
+  text: |-
+    Overall architecture
+  chunks:
+  - id: 3
+    text: |-
+      The general structure of a framework dealing with PII management could be visualized as the following diagram:

--- a/test/data/piicollection.json
+++ b/test/data/piicollection.json
@@ -2,7 +2,7 @@
   "metadata": {
     "date": "2000-01-01T00:00:00+00:00",
     "format": "pii:pii-collection",
-    "format_version": "0.2.1",
+    "format_version": "0.3.0",
     "detectors": {
       "1": {
         "name": "PII Finder",

--- a/test/data/piicollection.json
+++ b/test/data/piicollection.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "date": "2000-01-01T00:00:00Z",
+    "date": "2000-01-01T00:00:00+00:00",
     "format": "pii:pii-collection",
     "format_version": "0.2.1",
     "detectors": {

--- a/test/data/piicollection.ndjson
+++ b/test/data/piicollection.ndjson
@@ -1,3 +1,3 @@
-{"date": "2000-01-01T00:00:00Z", "format": "pii:pii-collection", "format_version": "0.2.1", "detectors": {"1": {"name": "PII Finder", "version": "0.1.0", "source": "PIISA"}}}
+{"date": "2000-01-01T00:00:00+00:00", "format": "pii:pii-collection", "format_version": "0.2.1", "detectors": {"1": {"name": "PII Finder", "version": "0.1.0", "source": "PIISA"}}}
 {"type": "GOV_ID", "value": "12345678", "chunkid": "12", "country": "br", "detector": 1, "lang": "pt", "docid": "doc1", "start": 15, "end": 23}
 {"type": "CREDIT_CARD", "value": "1234567890", "chunkid": "30", "country": "br", "detector": 1, "lang": "pt", "docid": "doc1", "start": 60, "end": 70}

--- a/test/data/piicollection.ndjson
+++ b/test/data/piicollection.ndjson
@@ -1,3 +1,3 @@
-{"date": "2000-01-01T00:00:00+00:00", "format": "pii:pii-collection", "format_version": "0.2.1", "detectors": {"1": {"name": "PII Finder", "version": "0.1.0", "source": "PIISA"}}}
+{"date": "2000-01-01T00:00:00+00:00", "format": "pii:pii-collection", "format_version": "0.3.0", "detectors": {"1": {"name": "PII Finder", "version": "0.1.0", "source": "PIISA"}}}
 {"type": "GOV_ID", "value": "12345678", "chunkid": "12", "country": "br", "detector": 1, "lang": "pt", "docid": "doc1", "start": 15, "end": 23}
 {"type": "CREDIT_CARD", "value": "1234567890", "chunkid": "30", "country": "br", "detector": 1, "lang": "pt", "docid": "doc1", "start": 60, "end": 70}

--- a/test/unit/types/test_document.py
+++ b/test/unit/types/test_document.py
@@ -1,0 +1,84 @@
+
+from pathlib import Path
+import tempfile
+
+from unittest.mock import Mock
+import pytest
+
+
+from pii_data.helper.io import load_yaml
+import pii_data.types.document as mod
+
+
+def fname(name: str) -> str:
+    return Path(__file__).parents[2] / "data" / name
+
+
+def readfile(name: str) -> str:
+    with open(name, "rt", encoding="utf-8") as f:
+        return f.read().strip()
+
+
+SIMPLEDOC = [
+    {"id": 1, "text": "an example text"},
+    {"id": 2, "text": "another example text"}
+]
+
+# ----------------------------------------------------------------
+
+@pytest.fixture
+def fix_uuid(monkeypatch):
+    """
+    Monkey-patch the document module to ensure a fixed uuid
+    """
+    mock_uuid = Mock()
+    mock_uuid.uuid4 = Mock(return_value="00000-11111")
+    monkeypatch.setattr(mod, 'uuid', mock_uuid)
+
+
+
+def test100_constructor(fix_uuid):
+    """Test object creation"""
+    obj = mod.SourceDocument()
+    assert str(obj) == "<SourceDocument 00000-11111>"
+
+
+def test110_constructor():
+    """Test object creation, data"""
+    obj = mod.SourceDocument(id="doc1", chunks=SIMPLEDOC)
+    assert str(obj) == "<SourceDocument doc1>"
+
+
+def test120_set():
+    """Test object creation, data"""
+    obj = mod.SourceDocument()
+    obj.set_id("doc1")
+    obj.set_chunks(SIMPLEDOC)
+    assert str(obj) == "<SourceDocument doc1>"
+
+
+def test200_iter():
+    """Test object iteration"""
+    obj = mod.SourceDocument("doc1", SIMPLEDOC)
+    got = list(obj)
+    exp = [
+        mod.DocumentChunk(1, "an example text"),
+        mod.DocumentChunk(2, "another example text")
+    ]
+    assert exp == got
+
+
+def test200_dump():
+    """Test object dump"""
+    obj = mod.SourceDocument("00000-11111")
+    obj.load(fname("doc-example.yaml"))
+
+    try:
+        f = tempfile.NamedTemporaryFile(mode="wt", suffix=".yml", delete=False)
+        obj.dump(f.name)
+        got = load_yaml(f.name)
+    finally:
+        Path(f.name).unlink()
+
+    exp = load_yaml(fname('doc-example-id.yaml'))
+    assert exp == got

--- a/test/unit/types/test_document.py
+++ b/test/unit/types/test_document.py
@@ -1,28 +1,26 @@
+"""
+Test the SrcDocument class
+"""
 
-from pathlib import Path
-import tempfile
 
 from unittest.mock import Mock
 import pytest
 
-
-from pii_data.helper.io import load_yaml
 import pii_data.types.document as mod
 
 
-def fname(name: str) -> str:
-    return Path(__file__).parents[2] / "data" / name
-
-
-def readfile(name: str) -> str:
-    with open(name, "rt", encoding="utf-8") as f:
-        return f.read().strip()
-
-
 SIMPLEDOC = [
-    {"id": 1, "text": "an example text"},
-    {"id": 2, "text": "another example text"}
+    "an example text",
+    "another example text",
+    "a third chunk"
 ]
+
+
+class ExampleSrcDoc(mod.SrcDocument):
+    """A child class for testing purposes"""
+    def get_chunks(self):
+        return iter(SIMPLEDOC)
+
 
 # ----------------------------------------------------------------
 
@@ -33,52 +31,135 @@ def fix_uuid(monkeypatch):
     """
     mock_uuid = Mock()
     mock_uuid.uuid4 = Mock(return_value="00000-11111")
-    monkeypatch.setattr(mod, 'uuid', mock_uuid)
+    monkeypatch.setattr(mod, "uuid", mock_uuid)
 
 
 
 def test100_constructor(fix_uuid):
     """Test object creation"""
-    obj = mod.SourceDocument()
-    assert str(obj) == "<SourceDocument 00000-11111>"
+    obj = mod.SrcDocument()
+    assert str(obj) == "<SrcDocument 00000-11111>"
 
 
-def test110_constructor():
-    """Test object creation, data"""
-    obj = mod.SourceDocument(id="doc1", chunks=SIMPLEDOC)
-    assert str(obj) == "<SourceDocument doc1>"
-
-
-def test120_set():
-    """Test object creation, data"""
-    obj = mod.SourceDocument()
+def test110_set():
+    """Test object creation, id"""
+    obj = mod.SrcDocument()
     obj.set_id("doc1")
-    obj.set_chunks(SIMPLEDOC)
-    assert str(obj) == "<SourceDocument doc1>"
+    assert str(obj) == "<SrcDocument doc1>"
+
+
+def test120_set_hdr():
+    """Test object creation, set header"""
+    obj = mod.SrcDocument()
+    obj.set_header_document({"id": "doc2"})
+    assert str(obj) == "<SrcDocument doc2>"
+
+
+def test130_set_get_hdr():
+    """Test object creation, set/get header"""
+    obj = mod.SrcDocument()
+    obj.add_metadata(document={"id": "doc2"})
+    assert str(obj) == "<SrcDocument doc2>"
 
 
 def test200_iter():
-    """Test object iteration"""
-    obj = mod.SourceDocument("doc1", SIMPLEDOC)
+    """Test iteration"""
+
+    obj = ExampleSrcDoc()
     got = list(obj)
+
     exp = [
-        mod.DocumentChunk(1, "an example text"),
-        mod.DocumentChunk(2, "another example text")
+        mod.DocumentChunk(id="1", data="an example text"),
+        mod.DocumentChunk(id="2", data="another example text"),
+        mod.DocumentChunk(id="3", data="a third chunk")
     ]
+
     assert exp == got
 
 
-def test200_dump():
-    """Test object dump"""
-    obj = mod.SourceDocument("00000-11111")
-    obj.load(fname("doc-example.yaml"))
+def test210_iter_ctx(fix_uuid):
+    """Test iteration, with context"""
 
-    try:
-        f = tempfile.NamedTemporaryFile(mode="wt", suffix=".yml", delete=False)
-        obj.dump(f.name)
-        got = load_yaml(f.name)
-    finally:
-        Path(f.name).unlink()
+    obj = ExampleSrcDoc(add_chunk_context=True)
+    got = list(obj)
 
-    exp = load_yaml(fname('doc-example-id.yaml'))
+    exp = [
+        mod.DocumentChunk(id="1", data="an example text",
+                          context={"document": {"id": "00000-11111"},
+                                   "after": "another example text"}),
+        mod.DocumentChunk(id="2", data="another example text",
+                          context={"document": {"id": "00000-11111"},
+                                   "before": "an example text",
+                                   "after": "a third chunk"}),
+        mod.DocumentChunk(id="3", data="a third chunk",
+                          context={"document": {"id": "00000-11111"},
+                                   "before": "another example text"})]
+
+    assert exp == got
+
+
+def test211_iter_ctx(fix_uuid):
+    """Test iteration, with context, explicit method"""
+
+    obj = ExampleSrcDoc()
+    got = obj.iter_chunks(add_context=True)
+
+    exp = [
+        mod.DocumentChunk(id="1", data="an example text",
+                          context={"document": {"id": "00000-11111"},
+                                   "after": "another example text"}),
+        mod.DocumentChunk(id="2", data="another example text",
+                          context={"document": {"id": "00000-11111"},
+                                   "before": "an example text",
+                                   "after": "a third chunk"}),
+        mod.DocumentChunk(id="3", data="a third chunk",
+                          context={"document": {"id": "00000-11111"},
+                                   "before": "another example text"})]
+
+    assert exp == list(got)
+
+
+def test220_iter_ctx_doc(fix_uuid):
+    """Test iteration, with document & chunk context"""
+
+    hdr = {"main_lang": "en", "id": "doc33"}
+    obj = ExampleSrcDoc(document_info=hdr, add_chunk_context=True)
+    got = list(obj)
+
+    exp = [
+        mod.DocumentChunk(id="1", data="an example text",
+                          context={"document": {"main_lang": "en", "id": "doc33"},
+                                   "after": "another example text"}),
+        mod.DocumentChunk(id="2", data="another example text",
+                          context={"document": {"main_lang": "en", "id": "doc33"},
+                                   "before": "an example text",
+                                   "after": "a third chunk"}),
+        mod.DocumentChunk(id="3", data="a third chunk",
+                          context={"document": {"main_lang": "en", "id": "doc33"},
+                                   "before": "another example text"})]
+    assert exp == got
+
+
+
+def test230_iter_metadata():
+    """Test iteration, w/ metadata"""
+
+    obj = ExampleSrcDoc({"id": "doc44"}, add_chunk_context=True)
+    obj.add_metadata(document={"main_lang": "en"}, dataset={"name": "BigDataset"})
+    got = list(obj)
+
+    exp = [
+        mod.DocumentChunk(id="1", data="an example text",
+                          context={"document": {"main_lang": "en", "id": "doc44"},
+                                   "dataset": {"name": "BigDataset"},
+                                   "after": "another example text"}),
+        mod.DocumentChunk(id="2", data="another example text",
+                          context={"document": {"main_lang": "en", "id": "doc44"},
+                                   "dataset": {"name": "BigDataset"},
+                                   "before": "an example text",
+                                   "after": "a third chunk"}),
+        mod.DocumentChunk(id="3", data="a third chunk",
+                          context={"document": {"main_lang": "en", "id": "doc44"},
+                                   "dataset": {"name": "BigDataset"},
+                                   "before": "another example text"})]
     assert exp == got

--- a/test/unit/types/test_document_tabular.py
+++ b/test/unit/types/test_document_tabular.py
@@ -1,0 +1,92 @@
+"""
+Test the TabularSrcDocument class
+"""
+
+
+from unittest.mock import Mock
+import pytest
+
+import pii_data.types.document as mod
+
+
+COLNAMES = ["Date", "Name", "Credit Card", "Currency", "Amount", "Description"]
+
+ROWS = [
+    ["2021-03-01", "John Smith", "4273 9666 4581 5642", "USD", "12.39",
+     "Our Iceberg Is Melting: Changing and Succeeding Under Any Conditions"],
+    ["2022-09-10", "Erik Jonsk", "4273 9666 4581 5642", "EUR", "11.99",
+     "Bedtime Originals Choo Choo Express Plush Elephant - Humphrey"],
+    ["2022-09-11", "John Smith", "4273 9666 4581 5642", "USD", "339.99",
+     "Robot Vacuum Mary,  Nobuk Robotic Vacuum Cleaner and Mop, 5000Pa Suction, Intelligent AI Mapping, Virtual Walls, Ideal for Pets Hair, Self-Charging, Carpets, Hard Floors, Tile, Wi-Fi, App Control"]
+]
+
+
+
+class ExampleTabularSrcDoc(mod.TabularSrcDocument):
+    """A child class for testing purposes"""
+    def get_chunks(self):
+        # Return in two chunks
+        return ROWS[0:2], ROWS[2:3]
+
+
+
+# ----------------------------------------------------------------
+
+@pytest.fixture
+def fix_uuid(monkeypatch):
+    """
+    Monkey-patch the document module to ensure a fixed uuid
+    """
+    mock_uuid = Mock()
+    mock_uuid.uuid4 = Mock(return_value="00000-11111")
+    monkeypatch.setattr(mod, "uuid", mock_uuid)
+
+
+
+def test100_constructor(fix_uuid):
+    """Test object creation"""
+    obj = mod.TreeSrcDocument()
+    assert str(obj) == "<SrcDocument 00000-11111>"
+
+
+def test120_set():
+    """Test object creation, id"""
+    obj = mod.TabularSrcDocument()
+    obj.set_id("doc1")
+    assert str(obj) == "<SrcDocument doc1>"
+
+
+def test120_set_hdr():
+    """Test object creation, set header"""
+    obj = mod.TabularSrcDocument()
+    obj.set_header_document({"id": "doc2"})
+    assert str(obj) == "<SrcDocument doc2>"
+
+
+def test200_iter():
+    """Test iteration"""
+
+    obj = ExampleTabularSrcDoc()
+
+    exp = [
+        mod.DocumentChunk(id='1', data=ROWS[0:2]),
+        mod.DocumentChunk(id='2', data=ROWS[2:3])
+    ]
+    got = list(obj)
+    assert exp == got
+
+
+def test210_iter_ctx(fix_uuid):
+    """Test iteration, with context"""
+
+    obj = ExampleTabularSrcDoc(add_chunk_context=True)
+
+    ctx_doc = {'id': '00000-11111'}
+    ctx_1 = {'document': ctx_doc, 'after': ROWS[2:3]}
+    ctx_2 = {'document': ctx_doc, 'before': ROWS[0:2]}
+    exp = [
+        mod.DocumentChunk(id='1', data=ROWS[0:2], context=ctx_1),
+        mod.DocumentChunk(id='2', data=ROWS[2:3], context=ctx_2)
+    ]
+    got = list(obj)
+    assert exp == got

--- a/test/unit/types/test_document_tree.py
+++ b/test/unit/types/test_document_tree.py
@@ -1,0 +1,130 @@
+"""
+Test the TreeSrcDocument class
+"""
+
+
+from unittest.mock import Mock
+import pytest
+
+import pii_data.types.document as mod
+
+
+TREEDOC = [
+    {
+        "data": "section 1",
+        "chunks": [
+            {"data": "subsection 1.1"},
+            {"data": "subsection 1.2"}
+        ]
+    },
+    {
+        "data": "section 2",
+        "chunks": [
+            {
+                "data": "subsection 2.1",
+                "chunks": [
+                    {"data": "subsection 2.1.1"}
+                ]
+            }
+        ]
+    },
+    {
+        "data": "section 3"
+    }
+]
+
+
+class ExampleTreeSrcDoc(mod.TreeSrcDocument):
+    """A child class for testing purposes"""
+    def top_chunks(self):
+        return iter(TREEDOC)
+
+
+
+# ----------------------------------------------------------------
+
+@pytest.fixture
+def fix_uuid(monkeypatch):
+    """
+    Monkey-patch the document module to ensure a fixed uuid
+    """
+    mock_uuid = Mock()
+    mock_uuid.uuid4 = Mock(return_value="00000-11111")
+    monkeypatch.setattr(mod, "uuid", mock_uuid)
+
+
+
+def test100_constructor(fix_uuid):
+    """Test object creation"""
+    obj = mod.TreeSrcDocument()
+    assert str(obj) == "<SrcDocument 00000-11111>"
+
+
+def test120_set():
+    """Test object creation, id"""
+    obj = mod.TreeSrcDocument()
+    obj.set_id("doc1")
+    assert str(obj) == "<SrcDocument doc1>"
+
+
+def test120_set_hdr():
+    """Test object creation, set header"""
+    obj = mod.TreeSrcDocument()
+    obj.set_header_document({"id": "doc2"})
+    assert str(obj) == "<SrcDocument doc2>"
+
+
+def test200_iter():
+    """Test iteration"""
+
+    obj = ExampleTreeSrcDoc()
+
+    exp = [
+        mod.DocumentChunk(id='1', data='section 1', context=None),
+        mod.DocumentChunk(id='2', data='subsection 1.1', context=None),
+        mod.DocumentChunk(id='3', data='subsection 1.2', context=None),
+        mod.DocumentChunk(id='4', data='section 2', context=None),
+        mod.DocumentChunk(id='5', data='subsection 2.1', context=None),
+        mod.DocumentChunk(id='6', data='subsection 2.1.1', context=None),
+        mod.DocumentChunk(id='7', data='section 3', context=None)
+    ]
+    got = list(obj)
+    assert exp == got
+
+
+def test210_iter_ctx(fix_uuid):
+    """Test iteration, with context"""
+
+    obj = ExampleTreeSrcDoc(add_chunk_context=True)
+
+    ctx_doc = {'id': '00000-11111'}
+    exp = [
+        mod.DocumentChunk(id='1', data='section 1',
+                          context={'document': ctx_doc,
+                                   'after': 'subsection 1.1'}),
+        mod.DocumentChunk(id='2', data='subsection 1.1',
+                          context={'document': ctx_doc,
+                                   'before': 'section 1',
+                                   'after': 'subsection 1.2'}),
+        mod.DocumentChunk(id='3', data='subsection 1.2',
+                          context={'document': ctx_doc,
+                                   'before': 'subsection 1.1',
+                                   'after': 'section 2'}),
+        mod.DocumentChunk(id='4', data='section 2',
+                          context={'document': ctx_doc,
+                                   'before': 'subsection 1.2',
+                                   'after': 'subsection 2.1'}),
+        mod.DocumentChunk(id='5', data='subsection 2.1',
+                          context={'document': ctx_doc,
+                                   'before': 'section 2',
+                                   'after': 'subsection 2.1.1'}),
+        mod.DocumentChunk(id='6', data='subsection 2.1.1',
+                          context={'document': ctx_doc,
+                                   'before': 'subsection 2.1',
+                                   'after': 'section 3'}),
+        mod.DocumentChunk(id='7', data='section 3',
+                          context={'document': ctx_doc,
+                                   'before': 'subsection 2.1.1'})]
+
+    got = list(obj)
+    assert exp == got

--- a/test/unit/types/test_localdoc.py
+++ b/test/unit/types/test_localdoc.py
@@ -1,0 +1,128 @@
+"""
+Test the LocalSrcDocument class
+"""
+
+
+from pathlib import Path
+import tempfile
+
+from unittest.mock import Mock
+import pytest
+
+
+from pii_data.helper.io import load_yaml
+import pii_data.types.document as doc
+import pii_data.types.localdoc as mod
+
+
+def fname(name: str) -> str:
+    return Path(__file__).parents[2] / "data" / name
+
+
+def readfile(name: str) -> str:
+    with open(name, "rt", encoding="utf-8") as f:
+        return f.read().strip()
+
+
+SIMPLEDOC = [
+    "an example text",
+    "another example text"
+]
+
+# ----------------------------------------------------------------
+
+@pytest.fixture
+def fix_uuid(monkeypatch):
+    """
+    Monkey-patch the document module to ensure a fixed uuid
+    """
+    mock_uuid = Mock()
+    mock_uuid.uuid4 = Mock(return_value="00000-11111")
+    monkeypatch.setattr(doc, 'uuid', mock_uuid)
+
+
+def test100_constructor(fix_uuid):
+    """Test object creation"""
+    obj = mod.LocalSrcDocument()
+    assert str(obj) == "<SrcDocument 00000-11111>"
+
+
+def test110_constructor():
+    """Test object creation, data"""
+    obj = mod.LocalSrcDocument(document_header={"id": "doc1"}, chunks=SIMPLEDOC)
+    assert str(obj) == "<SrcDocument doc1>"
+
+
+def test120_set():
+    """Test object creation, data"""
+    obj = mod.LocalSrcDocument()
+    obj.set_id("doc1")
+    obj.set_chunks(SIMPLEDOC)
+    assert str(obj) == "<SrcDocument doc1>"
+
+
+def test200_iter():
+    """Test object iteration"""
+    obj = mod.LocalSrcDocument(chunks=SIMPLEDOC)
+    got = list(obj)
+    exp = [
+        mod.DocumentChunk("1", "an example text"),
+        mod.DocumentChunk("2", "another example text")
+    ]
+    assert exp == got
+
+
+def test210_dump(fix_uuid):
+    """Test object dump"""
+    obj = mod.LocalSrcDocument(chunks=SIMPLEDOC)
+    try:
+        f = tempfile.NamedTemporaryFile(mode="wt", suffix=".yml", delete=False)
+        obj.dump(f.name)
+        got = load_yaml(f.name)
+    finally:
+        Path(f.name).unlink()
+
+    exp = {
+        'header': {
+            'document': {'id': '00000-11111'}
+        },
+        'chunks': ['an example text', 'another example text']
+    }
+    assert exp == got
+
+
+def test300_load_dump(fix_uuid):
+    """Test object load/dump, tree document"""
+
+    obj = mod.load_file(fname("doc-example-tree.yaml"))
+
+    # Dump to a YAML file, and load it back
+    try:
+        f = tempfile.NamedTemporaryFile(mode="wt", suffix=".yml", delete=False)
+        obj.dump(f.name)
+        got = load_yaml(f.name)
+    finally:
+        Path(f.name).unlink()
+
+    exp = load_yaml(fname('doc-example-tree-id.yaml'))
+    assert exp == got
+
+
+def test400_sequential(fix_uuid):
+    """Test sequential object dump"""
+    obj = mod.SequentialLocalSrcDocument(chunks=SIMPLEDOC)
+    try:
+        f = tempfile.NamedTemporaryFile(mode="wt", suffix=".yml", delete=False)
+        obj.dump(f.name)
+        got = load_yaml(f.name)
+    finally:
+        Path(f.name).unlink()
+
+    exp = {
+        'header': {
+            'document': {'id': '00000-11111', 'type': 'sequential'}
+        },
+        'chunks': ['an example text', 'another example text']
+    }
+    assert exp == got
+

--- a/test/unit/types/test_piientity.py
+++ b/test/unit/types/test_piientity.py
@@ -2,11 +2,27 @@
 from pii_data.types.piienum import PiiEnum
 import pii_data.types.piientity as mod
 
+import pytest
 
 
 def test10_object():
     """Test object creation"""
     obj = mod.PiiEntity(PiiEnum.CREDIT_CARD, "3412 2121 4121 4212", "12", 15)
+    assert str(obj) == "<PiiEntity CREDIT_CARD:3412 2121 4121 4212>"
+
+def test11_object_error():
+    """Test object creation, errors"""
+    with pytest.raises(TypeError):
+        mod.PiiEntity(PiiEnum.CREDIT_CARD, "3412 2121 4121 4212", "12")
+
+    with pytest.raises(TypeError):
+        mod.PiiEntity(PiiEnum.CREDIT_CARD, "3412 2121 4121 4212", "12", 15,
+                      44)
+
+def test12_object_kwargs():
+    """Test object creation, kwargs"""
+    obj = mod.PiiEntity(PiiEnum.CREDIT_CARD, "3412 2121 4121 4212", "12", 10,
+                        lang="ch")
     assert str(obj) == "<PiiEntity CREDIT_CARD:3412 2121 4121 4212>"
 
 


### PR DESCRIPTION
 * updated for data spec 0.3.0
 * added iteration with context
 * renamed `SourceDocument` to `SrcDocument`
 * local load/dump split from `SrcDocument,` into a `LocalSrcDocument` class + a module function
 * added base classes for tabular, tree & sequential docs
 * chunk payload change to `data` from `text`, to make it more generic